### PR TITLE
Allow Svelte bundlers to use the component directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Small web component to determine if clicks occur inside or outside a panel.",
   "main": "dist/PanelClick.cjs.js",
   "module": "dist/PanelClick.es2015.js",
+  "svelte": "PanelClick.html",
   "files": [
     "dist/PanelClick.cjs.js",
     "dist/PanelClick.es2015.js",


### PR DESCRIPTION
This prevents issues caused by newer versions of Svelte trying to use old compiled Svelte APIs.

This should be published as a feature version bump.